### PR TITLE
Actually use the value of the CLI argument to define the number of processes to be spawned.

### DIFF
--- a/bin/koa-cluster
+++ b/bin/koa-cluster
@@ -6,7 +6,7 @@ var cluster = require('cluster')
 program
   .usage('<app>')
   .option('-t, --title <str>', 'title of the process')
-  .option('-c, --cpu <int>', 'number of processes to use', parseInt)
+  .option('-p, --processes <int>', 'number of processes to use', parseInt)
   .parse(process.argv)
 
 // make sure the file exists
@@ -28,8 +28,15 @@ cluster.setupMaster({
   args: [requirename],
 })
 
-var cpus = require('os').cpus().length
-var procs = Math.ceil(0.75 * cpus)
+var procs;
+
+if(program.processes) {
+  procs = program.processes;
+} else {
+  var cpus = require('os').cpus().length
+  procs = Math.ceil(0.75 * cpus)
+}
+
 for (var i = 0; i < procs; i++) cluster.fork()
 
 // http://nodejs.org/api/cluster.html#cluster_event_disconnect

--- a/bin/koa-cluster
+++ b/bin/koa-cluster
@@ -30,7 +30,7 @@ cluster.setupMaster({
 
 var procs;
 
-if(program.processes) {
+if (program.processes) {
   procs = program.processes;
 } else {
   var cpus = require('os').cpus().length


### PR DESCRIPTION
Also change the name of the said argument from "--cpu" to "--processes" which is more accurate.